### PR TITLE
moving everything to a backend with node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,4 @@ node_modules
 *.sln
 *.sw?
 
-# Include dist only in the gh-pages branch
-!dist
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@material-tailwind/react": "^2.1.1",
+        "cookie": "^0.6.0",
+        "cookie-parser": "^1.4.6",
+        "crypto": "^1.0.1",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "react": "^18.2.0",
@@ -1594,9 +1597,29 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1619,6 +1642,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/css-in-js-utils": {
       "version": "3.1.0",
@@ -2226,6 +2255,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   },
   "dependencies": {
     "@material-tailwind/react": "^2.1.1",
+    "cookie": "^0.6.0",
+    "cookie-parser": "^1.4.6",
+    "crypto": "^1.0.1",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "react": "^18.2.0",

--- a/server.js
+++ b/server.js
@@ -1,18 +1,54 @@
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-
 import express from 'express';
 import path from 'path';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 const app = express();
 const port = process.env.PORT || 3000;
 
 app.use('/UnWrapped', express.static(path.join(__dirname, 'dist')));
 
+//this is the old redirect to auth code flow
+app.get('/authorize', (req,res) =>{
+    const verifier = generateCodeVerifier(128);
+    const challenge = generateCodeChallenge(verifier);
+
+    const params = new URLSearchParams();
+    params.append("client_id", clientId);
+    params.append("response_type", "code");
+    console.log(redirectURL);
+    params.append("redirect_uri", redirectURL);
+    //need to change this depending on what im requesting.
+    params.append("scope", "streaming user-read-private user-read-email user-read-playback-state user-modify-playback-state user-library-read user-read-recently-played user-top-read");
+    params.append("code_challenge_method", "S256");
+    params.append("code_challenge", challenge);
+
+    res.redirect(`https://accounts.spotify.com/authorize?${params.toString()}`);
+});
+
 app.listen(port, '0.0.0.0', () => {
     console.log(`Server is running on port ${port}`);
 });
+
+function generateCodeVerifier(length) {
+    let text = '';
+    let possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+    for (let i = 0; i < length; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+}
+
+async function generateCodeChallenge(codeVerifier) {
+    const data = Buffer.from(codeVerifier);
+    const digest = crypto.createHash('sha256').update(data).digest();
+    
+    return Buffer.from(digest)
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+}


### PR DESCRIPTION
Since this is running off of a VM and the node server entry point is the server.js, I need to move all the oauth functions to server.js.

redirectToAuthCodeFlow()
generateCodeVerifier()
generateCodeChallenge()
getAccessToken()

needs to be rewritten where functions like window.crypto or document.location has to be rewritten to fit server side js.

Im having troubles in the Statistics() function too where I need to somehow call the /authorize endpoint to launch the redirect. It ended up in a loop where it's constantly trying to authenticate and redirecting?

Also having CORS problems too
